### PR TITLE
Temperature sensor implementation for ESP32-S3 devices

### DIFF
--- a/build/config/mac/mac_sdk.gni
+++ b/build/config/mac/mac_sdk.gni
@@ -29,4 +29,7 @@ if (current_cpu == "x64") {
   mac_target_arch = current_cpu
 }
 
+mac_deployment_target = "12.0"
+mac_target_arch = "arm64"
+
 mac_target_triple = "${mac_target_arch}-apple-macos${mac_deployment_target}"

--- a/examples/temperature-measurement-app/esp32/main/DeviceCallbacks.cpp
+++ b/examples/temperature-measurement-app/esp32/main/DeviceCallbacks.cpp
@@ -33,6 +33,9 @@
 #include <app-common/zap-generated/cluster-id.h>
 #include <app/server/Dnssd.h>
 #include <lib/support/CodeUtils.h>
+#include "driver/temperature_sensor.h"
+
+#include <app-common/zap-generated/attributes/Accessors.h>
 
 static const char * TAG = "echo-devicecallbacks";
 
@@ -40,6 +43,8 @@ using namespace ::chip;
 using namespace ::chip::Inet;
 using namespace ::chip::System;
 using namespace ::chip::DeviceLayer;
+
+using namespace chip::app::Clusters;
 
 void DeviceCallbacks::DeviceEventCallback(const ChipDeviceEvent * event, intptr_t arg)
 {
@@ -112,4 +117,42 @@ void DeviceCallbacks::OnSessionEstablished(const ChipDeviceEvent * event)
     {
         ESP_LOGI(TAG, "Commissioner detected!");
     }
+}
+
+void TemperatureMeasurementAttributeReadAccessCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId)
+{
+    float tsens_out;
+
+    // Verify attribute and endpoint
+    VerifyOrReturn(attributeId == TemperatureMeasurement::Attributes::MeasuredValue::Id);
+    VerifyOrReturn(endpoint == 1);
+
+    // Read temperature from HW
+    if (temperature_sensor_get_celsius(temp_handle, &tsens_out) != ESP_OK)
+    {
+        ESP_LOGE(TAG, "Error reading temperature");
+        return;
+    }
+
+    // Update attribute
+    TemperatureMeasurement::Attributes::MeasuredValue::Set(1, static_cast<int16_t>(tsens_out * 100));
+    ESP_LOGI(TAG, "Temperature out celsius %.02f", tsens_out);
+}
+
+bool emberAfAttributeReadAccessCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId)
+{
+    ESP_LOGI(TAG, "emberAfAttributeReadAccessCallback - Cluster ID: '0x%04x', EndPoint ID: '0x%02x', Attribute ID: '0x%04x'", clusterId,
+             endpoint, attributeId);
+             
+    switch (clusterId)
+    {
+    case TemperatureMeasurement::Id:
+        TemperatureMeasurementAttributeReadAccessCallback(endpoint, clusterId, attributeId);
+        break;
+
+    default:
+        break;
+    }
+
+    return true;
 }

--- a/examples/temperature-measurement-app/esp32/main/include/CHIPDeviceManager.h
+++ b/examples/temperature-measurement-app/esp32/main/include/CHIPDeviceManager.h
@@ -38,6 +38,10 @@
 
 #include <app/util/af-types.h>
 
+#include "driver/temperature_sensor.h"
+
+extern temperature_sensor_handle_t temp_handle;
+
 namespace chip {
 namespace DeviceManager {
 

--- a/examples/temperature-measurement-app/esp32/main/main.cpp
+++ b/examples/temperature-measurement-app/esp32/main/main.cpp
@@ -27,6 +27,7 @@
 #include "freertos/task.h"
 #include "nvs_flash.h"
 #include <app/server/Server.h>
+#include <app-common/zap-generated/attributes/Accessors.h>
 
 #include <cmath>
 #include <cstdio>
@@ -48,6 +49,10 @@ using namespace ::chip;
 using namespace ::chip::Credentials;
 using namespace ::chip::DeviceManager;
 using namespace ::chip::DeviceLayer;
+
+using namespace chip::app::Clusters::TemperatureMeasurement::Attributes;
+
+temperature_sensor_handle_t temp_handle;
 
 const char * TAG = "temperature-measurement-app";
 
@@ -96,6 +101,13 @@ extern "C" void app_main()
         ESP_LOGE(TAG, "nvs_flash_init() failed: %s", esp_err_to_name(err));
         return;
     }
+
+    // Initialize touch pad peripheral, it will start a timer to run a filter
+    ESP_LOGI(TAG, "Initializing Temperature sensor");
+    temperature_sensor_config_t temp_sensor = TEMPERAUTRE_SENSOR_CONFIG_DEFAULT(10, 50);
+    ESP_ERROR_CHECK(temperature_sensor_install(&temp_sensor, &temp_handle));
+    ESP_ERROR_CHECK(temperature_sensor_start(temp_handle));
+    ESP_LOGI(TAG, "Temperature sensor started");
 
     CHIPDeviceManager & deviceMgr = CHIPDeviceManager::GetInstance();
 

--- a/scripts/build_python.sh
+++ b/scripts/build_python.sh
@@ -19,7 +19,7 @@
 set -e
 
 _normpath() {
-    python -c "import os.path; print(os.path.normpath('$@'))"
+    python3 -c "import os.path; print(os.path.normpath('$@'))"
 }
 
 echo_green() {

--- a/src/controller/python/chip-device-ctrl.py
+++ b/src/controller/python/chip-device-ctrl.py
@@ -946,7 +946,7 @@ class DeviceMgrCmd(Cmd):
                 self.do_help("set-pairing-wifi-credential")
                 return
             self.devCtrl.SetWiFiCredentials(
-                args[0].encode("utf-8"), args[1].encode("utf-8"))
+                args[0], args[1])
         except Exception as ex:
             print(str(ex))
             return


### PR DESCRIPTION
* Added workaround which allows to compile in MacOS computers with Apple Silicon.
* Full implementation of temperature measurement app for ESP32-S3 devices.
* Fixed encoding bug in chip-device-ctrl.

#### Problem
What is being fixed?  Examples:
* Fix crash on startup
* Fixes #12345 Frobnozzle is leaky (exactly like that, so GitHub will auto-close the issue).

#### Change overview
What's in this PR

#### Testing
How was this tested? (at least one bullet point required)
* If unit tests were added, how do they cover this issue?
* If unit tests existed, how were they fixed/modified to prevent this in future?
* If new unit tests are not added, why not?
* If integration tests were added, how do they verify this change?
* If new integration tests are not added, why not?
* If manually tested, what platforms controller and device platforms were manually tested, and how?
* If no testing is required, why not?
